### PR TITLE
Fix TypeError with JSON

### DIFF
--- a/qute-zotero
+++ b/qute-zotero
@@ -93,7 +93,7 @@ def main():
 
     if e["QUTE_MODE"] == "hints":
         r = get(url, headers={"User-Agent": e["QUTE_USER_AGENT"]})
-        html = r.content
+        html = r.text
         pdf = r.headers['Content-Type'].endswith('pdf')
 
     else:  # I guess this must be command mode


### PR DESCRIPTION
Error in hint mode if target isn't a pdf file:
```
ERROR: Userscript exited with status 1, see :messages for details.                                                                                                                            
ERROR: Process stderr:                                                                                                                                                                        
Traceback (most recent call last):                                                                                                                                                                     
  File "userscripts/zotero", line 129, in <module>
    main()
  File "userscripts/zotero", line 113, in main
    translator = detect(url, html)
  File "userscripts/zotero", line 53, in detect
    r = postExpectedOrFail("detect", 200, uri=uri, html=html)
  File "userscripts/zotero", line 44, in postExpectedOrFail
    r = post(zoteroapi + endpoint, json=kwargs, headers=headers, timeout=MAX_WAIT)
  File "/usr/lib/python3.7/site-packages/requests/api.py", line 116, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/usr/lib/python3.7/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python3.7/site-packages/requests/sessions.py", line 519, in request
    prep = self.prepare_request(req)
  File "/usr/lib/python3.7/site-packages/requests/sessions.py", line 462, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks), 
  File "/usr/lib/python3.7/site-packages/requests/models.py", line 316, in prepare
    self.prepare_body(data, files, json)
  File "/usr/lib/python3.7/site-packages/requests/models.py", line 466, in prepare_body
    body = complexjson.dumps(json)
  File "/usr/lib/python3.7/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type bytes is not JSON serializable
```